### PR TITLE
support %{format}t format

### DIFF
--- a/src/main/java/org/embulk/parser/apache/log/TimestampLogElementFactory.java
+++ b/src/main/java/org/embulk/parser/apache/log/TimestampLogElementFactory.java
@@ -1,5 +1,8 @@
 package org.embulk.parser.apache.log;
 
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
 import org.apache.commons.lang3.StringUtils;
 import org.embulk.spi.time.TimestampParser;
 
@@ -18,7 +21,30 @@ public class TimestampLogElementFactory implements LogElementFactory<TimestampLo
         if(StringUtils.isEmpty(parameter)){
             return new TimestampLogElement(task, name, "\\[([^\\]]+)\\]");
         }else{
-            return new TimestampLogElement(task, name, parameter);
+            String regex = toTimestampRegex(parameter);
+            return new TimestampLogElement(task, name, regex, parameter);
         }
+    }
+
+    private String toTimestampRegex(String parameter) {
+        String regex = "(" + parameter + ")";
+        regex = regex.replaceAll("\\[|\\]","\\\\$0");
+
+        regex = regex.replaceAll("%[abhpABPZ]","[A-z]+");
+        regex = regex.replaceAll("%c","[A-z]{3} [A-z]{3} \\\\d{2} \\\\d{2}:\\\\d{2}:\\\\d{2} \\\\d{4}");
+        regex = regex.replaceAll("%[dgmyCHIMSUVW]","\\\\d{2}");
+        regex = regex.replaceAll("%[Dx]","\\\\d{2}/\\\\d{2}/\\\\d{2}");
+        regex = regex.replaceAll("%[ekl]","[1-9 ]\\\\d");
+        regex = regex.replaceAll("%F","\\\\d{4}-\\\\d{2}-\\\\d{2}");
+        regex = regex.replaceAll("%[GY]","\\\\d{4}");
+        regex = regex.replaceAll("%j","\\\\d{3}");
+        regex = regex.replaceAll("%r","\\\\d{2}:\\\\d{2}:\\\\d{2} [A-z]+");
+        regex = regex.replaceAll("%R","\\\\d{2}:\\\\d{2}");
+        regex = regex.replaceAll("%s","\\\\d+");
+        regex = regex.replaceAll("%[TX]","\\\\d{2}:\\\\d{2}:\\\\d{2}");
+        regex = regex.replaceAll("%[uw]","\\\\d");
+        regex = regex.replaceAll("%z","\\\\+\\\\d{4}");
+
+        return regex;
     }
 }


### PR DESCRIPTION
formatを指定する場合の%tパラメータが未対応であったため、簡易対応のパッチを作成しました。

例えば、下記のように自分で時刻のフォーマットを指定した場合にもhttpd.confの設定と
同じ設定をembulkのconfigに設定することで対応できるようになります。

すべてを厳密に実装しているわけではないですが、通常の設定では使えるかと思いますので、
マージいただけると助かります。

```
(apacheのログ設定)
LogFormat "%{[%Y.%m.%d %T]}t %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\"" combined
```

```
(embulkのparserのフォーマット設定)
  parser:
    type: apache-custom-log
    format: "%{[%Y.%m.%d %T]}t %h %l %u %t \"%r\" %>s %O \"%{Referer}i\" \"%{User-Agent}i\""
```

quick hack apache custom log %{format}t

unsupport parameter:
- %E
- %n
- %O
- %t
- %+
- %%
